### PR TITLE
docs: fix old links from Gitlab to Github

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 ## Structure du projet
 
-La configuration se trouve dans le dossier [`./data/config.yml`](https://gitlab.com/natural-solutions/geonature/zones-humides/atlas/-/blob/1-write-docs-to-install-and-config/data/config.yml){.external-link target=\_blank} et est écrite au format [YAML][yaml]{ .external-link target=\_blank}.
+La configuration se trouve dans le dossier [`./data/config.yml`](https://github.com/PnX-SI/GeoNature-ZH-atlas/blob/main/data/config.yml){.external-link target=\_blank} et est écrite au format [YAML][yaml]{ .external-link target=\_blank}.
 
 ```bash
 .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: GeoNature Zones Humides · Atlas
 
-repo_name: geonature/zones-humides/atlas
-repo_url: https://gitlab.com/natural-solutions/geonature/zones-humides/atlas
+repo_name: GeoNature-ZH-atlas
+repo_url: https://github.com/PnX-SI/GeoNature-ZH-atlas
 
 theme:
   name: material


### PR DESCRIPTION
Replace old Gitlab links with Github 