### PR TITLE
fix: remove unused broken atlas-nginx service

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -43,9 +43,3 @@ git push origin main
 ```bash
 docker-compose up -d --build atlas
 ```
-
-#### ou Démarrer le projet avec `nginx`
-
-```bash
-docker-compose up -d --build atlas-nginx
-```


### PR DESCRIPTION
L'alternative de lancement atlas-nginx est obsolète

Reviewed-by: andriac